### PR TITLE
Resolve decidim installation path from `Gemfile.lock`

### DIFF
--- a/bin/decidimpack.js
+++ b/bin/decidimpack.js
@@ -1,29 +1,22 @@
 #!/usr/bin/env node
 
-const { exec, execSync } = require("child_process");
 const createBuilds = require("../src/create-builds");
+const resolveSource = require("../src/resolve-source");
+const path = require("path");
 
-const projectPath = process.argv[2];
+let projectPath = process.argv[2];
 if (!projectPath) {
   throw new Error("Please provide the project path as the first argument!");
 }
 
-const resolveSource = () => {
-  return new Promise((resolve, _reject) => {
-    exec("bundle show decidim", { stdio: "pipe" }, (error, stdout) => {
-      if (error) {
-        resolve("https://github.com/decidim/decidim/packages#develop");
-      } else {
-        resolve(`${stdout.trim()}/packages`);
-      }
-    });
-  });
-}
+// Normalize the path to remove any relative references
+projectPath = path.resolve(projectPath);
 
 const buildDir = `${projectPath}/tmp/npmbuild`;
 
-resolveSource().then((source) => {
+resolveSource(projectPath).then((source) => {
   console.log("Creating Decidim NPM builds...");
+  console.log(`  source: ${source}`);
   createBuilds(source, buildDir).then((packages) => {
     console.log("Builds created:");
     packages.forEach((pkg) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
+        "@snyk/gemfile": "github:ahukkanen/gemfile#fix/current-path-parent-path",
         "degit": "^2.8.4",
         "fs-extra": "^10.0.0"
       },
@@ -20,6 +21,13 @@
       "engines": {
         "node": "^15.14.0",
         "npm": "^7.7.2"
+      }
+    },
+    "node_modules/@snyk/gemfile": {
+      "resolved": "git+ssh://git@github.com/ahukkanen/gemfile.git#ae6791c0d4fd943aca25cb3c1a8b5d55a92afe68",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.2.4"
       }
     },
     "node_modules/degit": {
@@ -72,6 +80,10 @@
     }
   },
   "dependencies": {
+    "@snyk/gemfile": {
+      "version": "git+ssh://git@github.com/ahukkanen/gemfile.git#ae6791c0d4fd943aca25cb3c1a8b5d55a92afe68",
+      "from": "@snyk/gemfile@github:ahukkanen/gemfile#fix/current-path-parent-path"
+    },
     "degit": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@snyk/gemfile": "github:ahukkanen/gemfile#fix/current-path-parent-path",
     "degit": "^2.8.4",
     "fs-extra": "^10.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "decidimpack": "bin/decidimpack.js"
   },
   "scripts": {
-    "install": "decidimpack $INIT_CWD"
+    "install": "bin/decidimpack.js $INIT_CWD"
   },
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "decidimpack": "bin/decidimpack.js"
   },
   "scripts": {
-    "install": "npx node bin/decidimpack.js $INIT_CWD"
+    "install": "decidimpack $INIT_CWD"
   },
   "main": "index.js",
   "dependencies": {

--- a/src/resolve-source.js
+++ b/src/resolve-source.js
@@ -5,12 +5,12 @@ const resolveGemfileSource = (projectPath) => {
   return new Promise((resolve, reject) => {
     parseGemfile(`${projectPath}/Gemfile.lock`).then((gemfile) => {
       for (const [type, defs] of Object.entries(gemfile)) {
-        if (type.match(/GIT[0-9]*/)) {
+        if (type.match(/^GIT[0-9]*/)) {
           if (defs.specs["decidim"]) {
             resolve(`${defs.remote.path}/packages#${defs.revision.sha}`);
             return;
           }
-        } else if (type.match(/PATH[0-9]*/)) {
+        } else if (type.match(/^PATH[0-9]*/)) {
           if (defs.specs["decidim"]) {
             let gemPath = defs.remote.path;
             if (!gemPath) {

--- a/src/resolve-source.js
+++ b/src/resolve-source.js
@@ -45,17 +45,20 @@ const resolveGemfileSource = (projectPath) => {
 
 module.exports = (projectPath) => {
   return new Promise((resolve, _reject) => {
-    resolveBundleSource(projectPath).then(
-      (source) => resolve(source),
-      () => {
-        resolveGemfileSource(projectPath).then(
+    const tryList = [resolveBundleSource, resolveGemfileSource];
+    const tryNext = () => {
+      const current = tryList.shift();
+      if (current) {
+        current(projectPath).then(
           (source) => resolve(source),
-          () => {
-            // Default to Decidim git repository
-            resolve("https://github.com/decidim/decidim/packages#develop");
-          }
+          () => tryNext()
         );
+      } else {
+        // Default to Decidim git repository
+        resolve("https://github.com/decidim/decidim/packages#develop");
       }
-    );
+    };
+
+    tryNext();
   });
 };

--- a/src/resolve-source.js
+++ b/src/resolve-source.js
@@ -1,0 +1,43 @@
+const { parse: parseGemfile } = require("@snyk/gemfile");
+const path = require("path");
+
+const resolveGemfileSource = (projectPath) => {
+  return new Promise((resolve, reject) => {
+    parseGemfile(`${projectPath}/Gemfile.lock`).then((gemfile) => {
+      for (const [type, defs] of Object.entries(gemfile)) {
+        if (type.match(/GIT[0-9]*/)) {
+          if (defs.specs["decidim"]) {
+            resolve(`${defs.remote.path}/packages#${defs.revision.sha}`);
+            return;
+          }
+        } else if (type.match(/PATH[0-9]*/)) {
+          if (defs.specs["decidim"]) {
+            let gemPath = defs.remote.path;
+            if (!gemPath) {
+              continue;
+            }
+            if (!gemPath.match(/^\//)) {
+              gemPath = path.resolve(projectPath, gemPath);
+            }
+            if (gemPath) {
+              resolve(`${gemPath}/packages`);
+              return;
+            }
+          }
+        }
+      }
+    }, reject);
+  });
+};
+
+module.exports = (projectPath) => {
+  return new Promise((resolve, _reject) => {
+    resolveGemfileSource(projectPath).then(
+      (source) => resolve(source),
+      () => {
+        // Default to Decidim git repository
+        resolve("https://github.com/decidim/decidim/packages#develop");
+      }
+    );
+  });
+}


### PR DESCRIPTION
Right now the local npm package installation process runs `bundle show decidim` to determine the `decidim` gem installation path.

As discussed at https://github.com/decidim/decidim/pull/8159 with @leio10, this does not work correctly at Heroku because when the NPM dependencies are installed, Ruby and Bundler are not yet available.

This changes the behavior so that if `bundle show decidim` fails, it now reads the Decidim installation path from `Gemfile.lock` for git and path installations. This should ensure that the same version of the NPM dependencies are installed as defined in the `package-lock.json` to avoid the SHA integrity violations.

@leio10 I think this should provide a solution to the issue we discussed at:
https://github.com/decidim/decidim/pull/8159#issuecomment-871270349

---

**NOTE:** Right now I am using my own fork of `@snyk/gemfile` (the `Gemfile.lock` parser). The reason for this is that the current version of `@snyk/gemfile` does not work with the Decidim core's development_app and test_app Gemfiles because of this bug:
https://github.com/snyk/gemfile/pull/11